### PR TITLE
口座情報のAPI呼び出しのハンドラーの実装

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = { version = "0.1" }
 log = { version = "0.4" }
 env_logger = { version = "0.11" }
 actix-rt = { version = "2"}

--- a/src/handler/accounts.rs
+++ b/src/handler/accounts.rs
@@ -1,0 +1,652 @@
+use crate::dao::accounts::{AccountDao, AccountDaoImpl};
+use crate::model::accounts::Account;
+use actix_web::{HttpResponse, Result, web};
+use log::{error, info};
+use serde_json::json;
+use sqlx::SqlitePool;
+
+const API_BASE_PATH: &str = "/api/account";
+
+/// APIのルーティング設定
+/// # 引数
+/// * `cfg` - Actix WebのServiceConfigオブジェクト
+/// # 戻り値
+/// なし
+pub fn set_route(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope(API_BASE_PATH)
+            .service(
+                web::resource("")
+                    .route(web::get().to(
+                        |handler: web::Data<AccountHandlerImpl>,
+                         pool: web::Data<SqlitePool>,
+                         dao: web::Data<AccountDaoImpl>| async move {
+                            handler.get_accounts_list_all(pool, dao).await
+                        },
+                    ))
+                    .route(web::post().to(
+                        |handler: web::Data<AccountHandlerImpl>,
+                         pool: web::Data<SqlitePool>,
+                         dao: web::Data<AccountDaoImpl>,
+                         data: web::Json<Account>| async move {
+                            handler.create_account(pool, dao, data).await
+                        },
+                    ))
+                    .route(web::put().to(
+                        |handler: web::Data<AccountHandlerImpl>,
+                         pool: web::Data<SqlitePool>,
+                         dao: web::Data<AccountDaoImpl>,
+                         data: web::Json<Account>| async move {
+                            handler.update_account(pool, dao, data).await
+                        },
+                    )),
+            )
+            .service(
+                web::resource("/{id}")
+                    .route(web::get().to(
+                        |handler: web::Data<AccountHandlerImpl>,
+                         pool: web::Data<SqlitePool>,
+                         dao: web::Data<AccountDaoImpl>,
+                         path: web::Path<String>| async move {
+                            handler.get_account_by_id(pool, dao, path).await
+                        },
+                    ))
+                    .route(web::delete().to(
+                        |handler: web::Data<AccountHandlerImpl>,
+                         pool: web::Data<SqlitePool>,
+                         dao: web::Data<AccountDaoImpl>,
+                         path: web::Path<String>| async move {
+                            handler.delete_account(pool, dao, path).await
+                        },
+                    )),
+            )
+            .service(web::resource("/type/{type_name}").route(web::get().to(
+                |handler: web::Data<AccountHandlerImpl>,
+                 pool: web::Data<SqlitePool>,
+                 dao: web::Data<AccountDaoImpl>,
+                 path: web::Path<String>| async move {
+                    handler.get_accounts_list_by_type(pool, dao, path).await
+                },
+            ))),
+    );
+}
+
+// ハンドラートレイト定義（グローバルスコープに移動）
+#[async_trait::async_trait]
+pub trait AccountHandler {
+    async fn create_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        data: web::Json<Account>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+    async fn delete_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+    async fn get_account_by_id(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+    async fn get_accounts_list_all(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+    async fn get_accounts_list_by_type(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+    async fn update_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        data: web::Json<Account>,
+    ) -> Result<HttpResponse, actix_web::Error>;
+}
+
+/// 口座情報ハンドラーの実装
+#[derive(Clone)]
+pub struct AccountHandlerImpl;
+
+#[async_trait::async_trait]
+impl AccountHandler for AccountHandlerImpl {
+    /// 新しい口座情報を作成するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// * `data` - リクエストボディから取得した新しい口座情報
+    /// # 戻り値
+    /// 成功時はHTTP 201と作成された口座情報のJSON、失敗時はHTTP 500とエラーメッセージ
+    async fn create_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        data: web::Json<Account>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        info!("Received request to create a new account");
+        let account_id = data.id.clone();
+        // IDの重複チェック
+        let result = dao.get_account_by_id(&pool, &account_id).await;
+        match result {
+            Ok(account) => {
+                if account.is_some() {
+                    info!("Account with ID {} already exists.", account_id);
+                    return Ok(HttpResponse::Conflict().json(json!({"error": "Account ID already exists."})));
+                }
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                return Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to fetch account."})));
+            },
+        }
+        // 口座の作成
+        let result = dao.create_account(&pool, &data).await;
+        match result {
+            Ok(success_count) => {
+                info!("Created {} new account(s).", success_count);
+                Ok(HttpResponse::Created().json(json!({"created": success_count})))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to create account."})))
+            },
+        }
+    }
+
+    /// 指定されたIDの口座情報を削除するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// * `path` - URLパスから取得した口座ID
+    /// # 戻り値
+    /// 成功時はHTTP 200と成功メッセージ、失敗時はHTTP 500とエラーメッセージ
+    async fn delete_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        let account_id = path.as_str();
+        info!("Received request to delete account by ID: {}", account_id);
+        let result = dao.delete_account(&pool, account_id).await;
+        match result {
+            Ok(del_count) => {
+                if del_count == 0 {
+                    info!("No account found with ID: {}", account_id);
+                    return Ok(HttpResponse::NotFound().json(json!({"error": "Account not found."})));
+                }
+                info!("Deleted account with ID: {}", account_id);
+                Ok(HttpResponse::NoContent().json(json!({"message": "Account deleted successfully."})))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to delete account."})))
+            },
+        }
+    }
+
+    /// 指定されたIDの口座情報を取得するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// * `path` - URLパスから取得した口座ID
+    /// # 戻り値
+    /// 成功時はHTTP 200と口座情報のJSON、失敗時はHTTP 500とエラーメッセージ
+    async fn get_account_by_id(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        let account_id = path.as_str();
+        info!("Received request to fetch account by ID: {}", account_id);
+        let result = dao.get_account_by_id(&pool, account_id).await;
+        match result {
+            Ok(account) => {
+                if account.is_none() {
+                    info!("No account found with ID: {}", account_id);
+                    return Ok(HttpResponse::NotFound().json(json!({"error": "Account not found."})));
+                }
+                info!("Fetched account with ID: {}", account_id);
+                Ok(HttpResponse::Ok().json(account))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to fetch account."})))
+            },
+        }
+    }
+
+    /// 全ての口座情報を取得するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// # 戻り値
+    /// 成功時はHTTP 200と口座情報のJSON配列、失敗時はHTTP 500とエラーメッセージ
+    async fn get_accounts_list_all(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        info!("Received request to fetch all accounts");
+        let result = dao.get_accounts_list_all(&pool).await;
+        match result {
+            Ok(accounts) => {
+                info!("Fetched {} accounts.", accounts.len());
+                Ok(HttpResponse::Ok().json(accounts))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to fetch accounts."})))
+            },
+        }
+    }
+
+    /// 指定された口座種別の口座情報を取得するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// * `path` - URLパスから取得した口座種別名
+    /// # 戻り値
+    /// 成功時はHTTP 200と口座情報のJSON配列、失敗時はHTTP 500とエラーメッセージ
+    async fn get_accounts_list_by_type(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        path: web::Path<String>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        let type_name = path.as_str();
+        info!("Received request to fetch accounts of type: {}", type_name);
+        let result = dao.get_accounts_list_by_type(&pool, type_name).await;
+        match result {
+            Ok(accounts) => {
+                if accounts.is_empty() {
+                    info!("No accounts found for type: {}", type_name);
+                    return Ok(HttpResponse::NotFound().json(json!({"error": "No accounts found."})));
+                }
+                info!("Fetched {} accounts of type: {}", accounts.len(), type_name);
+                Ok(HttpResponse::Ok().json(accounts))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to fetch accounts."})))
+            },
+        }
+    }
+
+    /// 指定されたIDの口座情報を更新するハンドラー関数
+    /// # 引数
+    /// * `pool` - データベース接続プール
+    /// * `dao` - 口座情報DAO
+    /// * `data` - リクエストボディから取得した更新後の口座情報
+    /// # 戻り値
+    /// 成功時はHTTP 200と更新された口座情報のJSON、失敗時はHTTP 500とエラーメッセージ
+    async fn update_account(
+        &self,
+        pool: web::Data<SqlitePool>,
+        dao: web::Data<AccountDaoImpl>,
+        data: web::Json<Account>,
+    ) -> Result<HttpResponse, actix_web::Error> {
+        info!("Received request to update account by ID: {}", data.id);
+        let result = dao.update_account(&pool, &data).await;
+        match result {
+            Ok(updated_count) => {
+                if updated_count == 0 {
+                    info!("No account found with ID: {}", data.id);
+                    return Ok(HttpResponse::NotFound().json(json!({"error": "Account not found."})));
+                }
+                info!("Updated account with ID: {}", data.id);
+                Ok(HttpResponse::Ok().json(json!({"updated": updated_count})))
+            },
+            Err(e) => {
+                error!("Database error: {:?}", e);
+                Ok(HttpResponse::InternalServerError().json(json!({"error": "Failed to update account."})))
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::unit_test::fixtures::accounts as fixtures_accounts;
+    use crate::utils::unit_test::fixtures::db as fixtures_db;
+    use actix_web::body::to_bytes;
+    use actix_web::http::StatusCode;
+
+    async fn setup() -> (web::Data<SqlitePool>, web::Data<AccountDaoImpl>, AccountHandlerImpl) {
+        let (pool, dao, handler) = setup_empty().await;
+        fixtures_accounts::insert_test_account(&pool).await;
+        (pool, dao, handler)
+    }
+
+    async fn setup_empty() -> (web::Data<SqlitePool>, web::Data<AccountDaoImpl>, AccountHandlerImpl) {
+        let pool: web::Data<sqlx::Pool<sqlx::Sqlite>> = web::Data::new(fixtures_db::create_test_db().await);
+        let (dao, handler) = get_dao_and_handler();
+        (pool, dao, handler)
+    }
+
+    async fn setup_undefined() -> (web::Data<SqlitePool>, web::Data<AccountDaoImpl>, AccountHandlerImpl) {
+        let pool = web::Data::new(fixtures_db::create_undefined_db().await);
+        let (dao, handler) = get_dao_and_handler();
+        (pool, dao, handler)
+    }
+
+    fn get_dao_and_handler() -> (web::Data<AccountDaoImpl>, AccountHandlerImpl) {
+        let dao = web::Data::new(AccountDaoImpl);
+        let handler = AccountHandlerImpl;
+        (dao, handler)
+    }
+
+    mod create_account {
+        use super::*;
+
+        #[actix_web::test]
+        async fn create_success() {
+            // preparation
+            let (pool, dao, handler) = setup_empty().await;
+            let new_account = fixtures_accounts::get_first_account();
+            let new_account_json = web::Json(new_account.clone());
+            // execution
+            let resp = handler.create_account(pool, dao, new_account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::CREATED);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"created": 1}));
+        }
+
+        #[actix_web::test]
+        async fn create_conflict() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let existing_account = fixtures_accounts::get_first_account();
+            let existing_account_json = web::Json(existing_account.clone());
+            // execution
+            let resp = handler.create_account(pool, dao, existing_account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::CONFLICT);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Account ID already exists."}));
+        }
+
+        #[actix_web::test]
+        async fn create_servererror_on_check_exists() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            let new_account = fixtures_accounts::get_first_account();
+            let new_account_json = web::Json(new_account.clone());
+            // execution
+            let resp = handler.create_account(pool, dao, new_account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to fetch account."}));
+        }
+
+        // TODO: モックを使えるようになってから
+        // #[actix_web::test]
+        // async fn create_servererror_on_creation() {
+        //     // preparation
+        //     let (pool, dao, handler) = setup_undefined().await;
+        //     let new_account = fixtures_accounts::get_first_account();
+        //     let new_account_json = web::Json(new_account.clone());
+        //     // execution
+        //     let resp = handler.create_account(pool, dao, new_account_json).await.unwrap();
+        //     // assersion
+        //     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        //     let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+        //     let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        //     assert_eq!(body, json!({"error": "Failed to create account."}));
+        // }
+    }
+
+    mod get_accounts_list_all {
+        use super::*;
+
+        #[actix_web::test]
+        async fn get_all_is_empty() {
+            // preparation
+            let (pool, dao, handler) = setup_empty().await;
+            // execution
+            let resp = handler.get_accounts_list_all(pool, dao).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(accounts.len(), 0);
+        }
+
+        #[actix_web::test]
+        async fn get_all_found_3accounts() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let account_list = fixtures_accounts::get_sorted_account_list();
+            // execution
+            let resp = handler.get_accounts_list_all(pool, dao).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(accounts.len(), 3);
+            assert_eq!(accounts[0].id, account_list[0].id);
+            assert_eq!(accounts[1].id, account_list[1].id);
+            assert_eq!(accounts[2].id, account_list[2].id);
+        }
+
+        #[actix_web::test]
+        async fn get_all_servererror() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            // execution
+            let resp = handler.get_accounts_list_all(pool, dao).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to fetch accounts."}));
+        }
+    }
+
+    mod get_accounts_list_by_type {
+        use super::*;
+
+        #[actix_web::test]
+        async fn get_type_not_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let path = web::Path::from("Other".to_string());
+            // execution
+            let resp = handler.get_accounts_list_by_type(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "No accounts found."}));
+        }
+
+        #[actix_web::test]
+        async fn get_type_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let account = fixtures_accounts::get_first_account();
+            let path = web::Path::from(account.account_type.name.clone());
+            // execution
+            let resp = handler.get_accounts_list_by_type(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(accounts.len(), 1);
+            assert_eq!(accounts[0].id, account.id);
+        }
+
+        #[actix_web::test]
+        async fn get_type_servererror() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            let account = fixtures_accounts::get_first_account();
+            let path = web::Path::from(account.account_type.name.clone());
+            // execution
+            let resp = handler.get_accounts_list_by_type(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to fetch accounts."}));
+        }
+    }
+
+    mod get_accounts_by_id {
+        use super::*;
+
+        #[actix_web::test]
+        async fn get_by_id_not_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let path = web::Path::from("nonexistent_id".to_string());
+            // execution
+            let resp = handler.get_account_by_id(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Account not found."}));
+        }
+
+        #[actix_web::test]
+        async fn get_by_id_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let account = fixtures_accounts::get_first_account();
+            let path = web::Path::from(account.id.clone());
+            // execution
+            let resp = handler.get_account_by_id(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let fetched_account: Account = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(fetched_account.id, account.id);
+        }
+
+        #[actix_web::test]
+        async fn get_by_id_servererror() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            let path = web::Path::from("any_id".to_string());
+            // execution
+            let resp = handler.get_account_by_id(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to fetch account."}));
+        }
+    }
+
+    mod delete_account {
+        use super::*;
+
+        #[actix_web::test]
+        async fn delete_not_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let path = web::Path::from("nonexistent_id".to_string());
+            // execution
+            let resp = handler.delete_account(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Account not found."}));
+        }
+
+        #[actix_web::test]
+        async fn delete_success() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let account = fixtures_accounts::get_first_account();
+            let path = web::Path::from(account.id.clone());
+            // execution
+            let resp = handler.delete_account(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"message": "Account deleted successfully."}));
+        }
+
+        #[actix_web::test]
+        async fn delete_servererror() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            let path = web::Path::from("any_id".to_string());
+            // execution
+            let resp = handler.delete_account(pool, dao, path).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to delete account."}));
+        }
+    }
+
+    mod update_account {
+        use super::*;
+
+        #[actix_web::test]
+        async fn update_not_found() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let account = fixtures_accounts::create_new_account();
+            let account_json = web::Json(account);
+            // execution
+            let resp = handler.update_account(pool, dao, account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Account not found."}));
+        }
+
+        #[actix_web::test]
+        async fn update_success() {
+            // preparation
+            let (pool, dao, handler) = setup().await;
+            let mut account = fixtures_accounts::get_first_account();
+            account.memo = Some("更新されたメモ".to_string());
+            let account_json = web::Json(account.clone());
+            // execution
+            let resp = handler.update_account(pool, dao, account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"updated": 1}));
+        }
+
+        #[actix_web::test]
+        async fn update_servererror() {
+            // preparation
+            let (pool, dao, handler) = setup_undefined().await;
+            let account = fixtures_accounts::get_first_account();
+            let account_json = web::Json(account);
+            // execution
+            let resp = handler.update_account(pool, dao, account_json).await.unwrap();
+            // assersion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to update account."}));
+        }
+    }
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,0 +1,1 @@
+pub mod accounts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod dao;
+pub mod handler;
 pub mod model;
 pub mod utils;

--- a/src/utils/app_setup.rs
+++ b/src/utils/app_setup.rs
@@ -1,4 +1,5 @@
 use crate::dao::accounts::AccountDaoImpl;
+use crate::handler::accounts;
 use actix_web::{App, HttpResponse, HttpServer, Responder, web};
 use log::{debug, info};
 use serde_json::json;
@@ -22,9 +23,11 @@ pub fn create_app_data(pool: &SqlitePool) -> AppData {
     AppData { db_pool: pool.clone(), account_dao: AccountDaoImpl }
 }
 
-/// 各ハンドラーのconfigure関数をまとめて返す関数
+/// 各APIのルーティング設定をする関数
 fn set_route_config(cfg: &mut web::ServiceConfig) {
     debug!("Setting up route configurations.");
+    accounts::set_route(cfg);
+    debug!("Route configurations set up successfully.");
 }
 
 /// Actix Webアプリケーションのファクトリ関数

--- a/src/utils/unit_test/fixtures/db.rs
+++ b/src/utils/unit_test/fixtures/db.rs
@@ -4,6 +4,7 @@ use std::fs;
 use uuid::Uuid;
 
 const MIGRATIONS_DIR: &str = "./migrations";
+const UNDEFINED_DB: &str = "./undefined.db";
 
 // テスト用のインメモリSQLiteデータベースをセットアップするヘルパー関数
 pub async fn create_test_db() -> SqlitePool {
@@ -26,5 +27,13 @@ pub async fn create_test_db() -> SqlitePool {
             .await
             .unwrap_or_else(|e| panic!("Failed to execute migration: {}: {}", path.display(), e));
     }
+    pool
+}
+
+// スキーマが設定されていないDBへのアクセスプールを作成する
+pub async fn create_undefined_db() -> SqlitePool {
+    fs::OpenOptions::new().write(true).create(true).open(UNDEFINED_DB).expect("Failed to create undefined.db file");
+    let db_url = format!("sqlite:{}", UNDEFINED_DB);
+    let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
     pool
 }

--- a/tests/common/fixtures/accounts.rs
+++ b/tests/common/fixtures/accounts.rs
@@ -1,0 +1,86 @@
+use ebisu_api::model::accounts::{Account, AccountType};
+use serde::Deserialize;
+use sqlx::SqlitePool;
+use std::fs;
+
+const TEST_ACCOUNT_DATA_PATH: &str = "tests/data/accounts.yaml";
+
+#[derive(Debug, Deserialize)]
+struct YamlAccount {
+    id: String,
+    name: String,
+    account_type: YamlAccountType,
+    memo: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YamlAccountType {
+    id: i64,
+    name: String,
+}
+
+// テスト用に口座情報を追加するヘルパー関数
+pub async fn insert_account(pool: &SqlitePool, account_row: &Account) {
+    sqlx::query!(
+        "INSERT INTO accounts
+            (id, name, account_type_id, memo) VALUES (?1, ?2, ?3, ?4)",
+        account_row.id,
+        account_row.name,
+        account_row.account_type.id,
+        account_row.memo,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// テスト用口座種別を挿入するヘルパー関数
+pub async fn insert_test_account(pool: &SqlitePool) {
+    for account in load_accounts_from_yaml() {
+        insert_account(pool, &account).await;
+    }
+}
+
+// YAMLファイルからテスト用口座情報を読み込むヘルパー関数
+pub fn load_accounts_from_yaml() -> Vec<Account> {
+    let yaml_str = fs::read_to_string(TEST_ACCOUNT_DATA_PATH).expect("Failed to read YAML file");
+    let yaml_accounts: Vec<YamlAccount> = serde_yaml::from_str(&yaml_str).expect("Failed to parse YAML");
+    yaml_accounts
+        .into_iter()
+        .map(|ya| Account {
+            id: ya.id,
+            name: ya.name,
+            account_type: AccountType { id: ya.account_type.id, name: ya.account_type.name },
+            memo: ya.memo,
+            created_at: None,
+            updated_at: None,
+        })
+        .collect()
+}
+
+// テスト用口座リストを取得するヘルパー関数
+pub fn get_account_list() -> Vec<Account> {
+    load_accounts_from_yaml()
+}
+
+// 名前順にソートされたテスト用口座リストを取得するヘルパー関数
+pub fn get_sorted_account_list() -> Vec<Account> {
+    let mut accounts = load_accounts_from_yaml();
+    accounts.sort_by(|a, b| a.name.cmp(&b.name));
+    accounts
+}
+
+pub fn get_first_account() -> Account {
+    get_sorted_account_list().first().unwrap().clone()
+}
+
+pub fn create_new_account() -> Account {
+    Account {
+        id: "44444444-4444-4444-4444-444444444444".to_string(),
+        name: "追加の普通口座".to_string(),
+        account_type: AccountType { id: 2, name: "銀行口座(普通)".to_string() },
+        memo: Some("追加の普通口座のメモ".to_string()),
+        created_at: None,
+        updated_at: None,
+    }
+}

--- a/tests/common/fixtures/db.rs
+++ b/tests/common/fixtures/db.rs
@@ -1,0 +1,49 @@
+use crate::common::fixtures::accounts;
+use sqlx::{Executor, SqlitePool, sqlite::SqlitePoolOptions};
+use std::fs;
+use uuid::Uuid;
+
+const MIGRATIONS_DIR: &str = "./migrations";
+const UNDEFINED_DB: &str = "./undefined.db";
+
+// テスト用のインメモリSQLiteデータベースをセットアップする
+
+// 空のデータベースを作成する
+pub async fn create_empty_db() -> SqlitePool {
+    migrate_test_db().await
+}
+
+// テストデータが入ったデータベースを作成する
+pub async fn create_test_db() -> SqlitePool {
+    let pool = migrate_test_db().await;
+    accounts::insert_test_account(&pool).await;
+    pool
+}
+
+// スキーマが設定されていないDBへのアクセスプールを作成する
+pub async fn create_undefined_db() -> SqlitePool {
+    fs::OpenOptions::new().write(true).create(true).open(UNDEFINED_DB).expect("Failed to create undefined.db file");
+    let db_url = format!("sqlite:{}", UNDEFINED_DB);
+    let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+    pool
+}
+
+// マイグレーションを適用したテスト用データベースを作成する
+pub async fn migrate_test_db() -> SqlitePool {
+    let db_name = format!("file:memdb-{}", Uuid::new_v4().to_string());
+    let db_url = format!("{}?mode=memory&cache=shared", db_name);
+    let pool = SqlitePoolOptions::new().max_connections(1).connect(&db_url).await.unwrap();
+    let mut conn = pool.acquire().await.unwrap();
+    // マイグレーションファイルを読み込み、順番に実行する
+    let paths = fs::read_dir(MIGRATIONS_DIR).expect("Failed to read migrations directory");
+    for entry in paths {
+        let path = entry.expect("Failed to get entry").path();
+        if path.extension().map_or(false, |ext| ext == "sql") {
+            let sql_content = fs::read_to_string(&path).expect(&format!("Failed to read SQL file: {}", path.display()));
+            conn.execute(sql_content.as_str())
+                .await
+                .expect(&format!("Failed to execute migration: {}", path.display()));
+        }
+    }
+    pool
+}

--- a/tests/common/fixtures/mod.rs
+++ b/tests/common/fixtures/mod.rs
@@ -1,0 +1,2 @@
+pub mod accounts;
+pub mod db;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod fixtures;

--- a/tests/handler/accounts.rs
+++ b/tests/handler/accounts.rs
@@ -1,0 +1,341 @@
+use crate::common::fixtures::accounts as fixtures_accounts;
+use crate::common::fixtures::db as fixtures_db;
+use actix_web::dev::ServiceResponse;
+use actix_web::http::StatusCode;
+use actix_web::{App, test, web};
+use ebisu_api::dao::accounts::AccountDaoImpl;
+use ebisu_api::handler::accounts::AccountHandlerImpl;
+use ebisu_api::handler::accounts::set_route as accounts_configure;
+use ebisu_api::model::accounts::Account;
+use serde_json::json;
+use sqlx::{Pool, Sqlite};
+use std::vec;
+
+const API_BASE_PATH: &str = "/api/account";
+
+enum HttpMethod {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+}
+
+// APIを呼び出すヘルパー関数
+async fn call_api(
+    pool: &Pool<Sqlite>,
+    method: HttpMethod,
+    api_path: &str,
+    send_body: Option<&Account>,
+) -> ServiceResponse {
+    let dao = AccountDaoImpl;
+    let handler = AccountHandlerImpl;
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .app_data(web::Data::new(dao))
+            .app_data(web::Data::new(handler))
+            .configure(accounts_configure),
+    )
+    .await;
+    let req = {
+        match method {
+            HttpMethod::GET => test::TestRequest::get().uri(api_path).to_request(),
+            HttpMethod::POST => test::TestRequest::post().uri(api_path).set_json(send_body).to_request(),
+            HttpMethod::PUT => test::TestRequest::put().uri(api_path).set_json(send_body).to_request(),
+            HttpMethod::DELETE => test::TestRequest::delete().uri(api_path).to_request(),
+        }
+    };
+    let resp = test::call_service(&app, req).await;
+    resp
+}
+
+mod get_account {
+    use super::*;
+
+    #[actix_web::test]
+    pub async fn get_all_is_empty() {
+        // preparation
+        let pool = fixtures_db::create_empty_db().await;
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Vec<Account> = test::read_body_json(resp).await;
+        assert_eq!(body, vec![]);
+    }
+
+    #[actix_web::test]
+    pub async fn get_all_found_3accounts() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let accounts = fixtures_accounts::get_sorted_account_list();
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Vec<Account> = test::read_body_json(resp).await;
+        assert_eq!(body.len(), 3);
+        assert_eq!(body[0].id, accounts[0].id);
+        assert_eq!(body[1].id, accounts[1].id);
+        assert_eq!(body[2].id, accounts[2].id);
+    }
+
+    #[actix_web::test]
+    pub async fn get_all_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Failed to fetch accounts."}));
+    }
+}
+
+mod get_account_type {
+    use super::*;
+
+    #[actix_web::test]
+    pub async fn get_type_is_found() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let account = fixtures_accounts::get_first_account();
+        let encoded_type: String = url::form_urlencoded::byte_serialize(account.account_type.name.as_bytes()).collect();
+        // execution
+        let api_path = format!("{}/type/{}", API_BASE_PATH, encoded_type);
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Vec<Account> = test::read_body_json(resp).await;
+        assert_eq!(body.len(), 1);
+    }
+
+    #[actix_web::test]
+    pub async fn get_type_not_found() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        // execution
+        let api_path = format!("{}/type/{}", API_BASE_PATH, "Other");
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "No accounts found."}));
+    }
+
+    #[actix_web::test]
+    pub async fn get_type_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        let account = fixtures_accounts::get_first_account();
+        let encoded_type: String = url::form_urlencoded::byte_serialize(account.account_type.name.as_bytes()).collect();
+        // execution
+        let api_path = format!("{}/type/{}", API_BASE_PATH, encoded_type);
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Failed to fetch accounts."}));
+    }
+}
+
+mod get_account_id {
+    use super::*;
+
+    #[actix_web::test]
+    pub async fn get_id_is_found() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let account_id = fixtures_accounts::get_first_account().id;
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account_id);
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Account = test::read_body_json(resp).await;
+        assert_eq!(body.id, account_id);
+    }
+
+    #[actix_web::test]
+    pub async fn get_id_not_found() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let account_id = "55555555-5555-5555-5555-555555555555".to_string();
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account_id);
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Account not found."}));
+    }
+
+    #[actix_web::test]
+    pub async fn get_id_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        let account_id = fixtures_accounts::get_first_account().id;
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account_id);
+        let resp = call_api(&pool, HttpMethod::GET, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Failed to fetch account."}));
+    }
+}
+
+mod post_account {
+    use super::*;
+
+    #[actix_web::test]
+    pub async fn create_account_success() {
+        // preparation and execution
+        let pool = fixtures_db::create_empty_db().await;
+        let new_account = fixtures_accounts::create_new_account();
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::POST, &api_path, Some(&new_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"created": 1}));
+    }
+
+    #[actix_web::test]
+    pub async fn create_account_deprecated() {
+        // preparation and execution
+        let pool = fixtures_db::create_empty_db().await;
+        let new_account = fixtures_accounts::create_new_account();
+        // execution
+        let api_path = API_BASE_PATH;
+        let _ = call_api(&pool, HttpMethod::POST, &api_path, Some(&new_account)).await;
+        let resp = call_api(&pool, HttpMethod::POST, &api_path, Some(&new_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Account ID already exists."}));
+    }
+
+    #[actix_web::test]
+    pub async fn create_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        let new_account = fixtures_accounts::create_new_account();
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::POST, &api_path, Some(&new_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        // 重複チェックのエラーしか確認が難しい（登録時のエラーは単体テストで確認する）
+        assert_eq!(body, json!({"error": "Failed to fetch account."}));
+    }
+}
+
+mod delete_account {
+    use super::*;
+
+    #[actix_web::test]
+    pub async fn delete_account_success() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let account = fixtures_accounts::get_first_account();
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account.id);
+        let resp = call_api(&pool, HttpMethod::DELETE, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"message": "Account deleted successfully."}));
+    }
+
+    #[actix_web::test]
+    pub async fn delete_account_not_found() {
+        // preparation
+        let pool = fixtures_db::create_empty_db().await;
+        fixtures_accounts::insert_test_account(&pool).await;
+        let account_id = "55555555-5555-5555-5555-555555555555".to_string();
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account_id);
+        let resp = call_api(&pool, HttpMethod::DELETE, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Account not found."}));
+    }
+
+    #[actix_web::test]
+    pub async fn delete_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        let account_id = fixtures_accounts::get_first_account().id;
+        // execution
+        let api_path = format!("{}/{}", API_BASE_PATH, account_id);
+        let resp = call_api(&pool, HttpMethod::DELETE, &api_path, None).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Failed to delete account."}));
+    }
+}
+
+mod put_account {
+    use super::*;
+    use tokio::time::{Duration, sleep};
+
+    #[actix_web::test]
+    pub async fn update_account_success() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let before = fixtures_accounts::get_first_account();
+        let before_updated_at = before.updated_at.clone();
+        let mut update_account = before.clone();
+        update_account.memo = Some("更新されたメモ".to_string());
+        update_account.updated_at = None;
+        sleep(Duration::from_secs(1)).await; // updated_atの差分を確実にするため、少し待機
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::PUT, &api_path, Some(&update_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"updated": 1}));
+        // 更新後のデータの確認
+        let updated_api_path = format!("{}/{}", API_BASE_PATH, update_account.id);
+        let updated_resp = call_api(&pool, HttpMethod::GET, &updated_api_path, None).await;
+        let updated_body: Account = test::read_body_json(updated_resp).await;
+        assert_eq!(updated_body.id, update_account.id);
+        assert_eq!(updated_body.name, update_account.name);
+        assert_eq!(updated_body.account_type, update_account.account_type);
+        assert_eq!(updated_body.memo, update_account.memo);
+        assert_ne!(updated_body.updated_at, before_updated_at);
+        assert_ne!(updated_body.created_at, updated_body.updated_at);
+    }
+
+    #[actix_web::test]
+    pub async fn update_account_not_found() {
+        // preparation
+        let pool = fixtures_db::create_test_db().await;
+        let update_account = fixtures_accounts::create_new_account();
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::PUT, &api_path, Some(&update_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Account not found."}));
+    }
+
+    #[actix_web::test]
+    pub async fn update_server_error() {
+        let pool = fixtures_db::create_undefined_db().await;
+        let update_account = fixtures_accounts::create_new_account();
+        // execution
+        let api_path = API_BASE_PATH;
+        let resp = call_api(&pool, HttpMethod::PUT, &api_path, Some(&update_account)).await;
+        // assertion
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body, json!({"error": "Failed to update account."}));
+    }
+}

--- a/tests/handler/mod.rs
+++ b/tests/handler/mod.rs
@@ -1,0 +1,1 @@
+pub mod accounts;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod common;
+pub mod handler;


### PR DESCRIPTION
- 口座情報APIのハンドラーを実装
- app_setup.rsにAPIのルーティング設定を追加
- API結合テストのテストコードを実装