### PR TITLE
feat: shakuによるDIコンテナ導入・Dao/HandlerのDI化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ once_cell = { version = "1.21.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_yaml = { version = "0.9.33" }
+shaku = { version = "0.6.2" , features = ["derive"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 strfmt = { version = "0.2.5" }
 tokio = { version = "1", features = ["full"] }

--- a/src/dao/accounts.rs
+++ b/src/dao/accounts.rs
@@ -15,14 +15,14 @@ pub trait AccountDao {
 }
 
 /// AccountDaoトレイトの実装。
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct AccountDaoImpl;
 
 /// AccountDaoImplのコンストラクタ
 impl AccountDaoImpl {
     /// AccountDaoImplの新しいインスタンスを生成する。
     pub fn new() -> Self {
-        AccountDaoImpl
+        Default::default()
     }
 
     /// AccountDaoImplの新しいArcラップされたインスタンスを生成する。

--- a/src/dao/accounts.rs
+++ b/src/dao/accounts.rs
@@ -1,11 +1,12 @@
 use crate::entity::accounts::{Account, AccountType};
 use log::{debug, info};
+use shaku::{Component, Interface};
 use sqlx::{FromRow, Result, SqlitePool};
 use std::sync::Arc;
 
 /// 口座情報に関するデータアクセスオブジェクト(DAO)のトレイト定義。
 #[async_trait::async_trait]
-pub trait AccountDao {
+pub trait AccountDao: Interface {
     async fn get_accounts_list_all(&self, pool: &SqlitePool) -> Result<Vec<Account>>;
     async fn get_accounts_list_by_type(&self, pool: &SqlitePool, account_type_name: &str) -> Result<Vec<Account>>;
     async fn get_account_by_id(&self, pool: &SqlitePool, id: &str) -> Result<Option<Account>>;
@@ -15,7 +16,8 @@ pub trait AccountDao {
 }
 
 /// AccountDaoトレイトの実装。
-#[derive(Clone, Default)]
+#[derive(Clone, Component, Default)]
+#[shaku(interface = AccountDao)]
 pub struct AccountDaoImpl;
 
 /// AccountDaoImplのコンストラクタ

--- a/src/handler/accounts.rs
+++ b/src/handler/accounts.rs
@@ -149,12 +149,12 @@ pub trait AccountHandler {
 }
 
 /// 口座情報ハンドラーの実装
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct AccountHandlerImpl;
 
 impl AccountHandlerImpl {
     pub fn new() -> Self {
-        AccountHandlerImpl
+        Default::default()
     }
 
     pub fn new_arc() -> Arc<dyn AccountHandler + Send + Sync> {

--- a/src/handler/accounts.rs
+++ b/src/handler/accounts.rs
@@ -1,4 +1,3 @@
-use crate::dao::accounts::AccountDao;
 use crate::entity::accounts::Account;
 use crate::utils::app_setup::AppData;
 use crate::utils::message::{MessageHierarchy, set_hierarchy};
@@ -6,6 +5,7 @@ use actix_web::{HttpResponse, Result, web};
 use log::{error, info};
 use once_cell::sync::Lazy;
 use serde_json::json;
+use shaku::{Component, Interface};
 use std::sync::Arc;
 
 const MODULE_PATH: &str = module_path!();
@@ -119,7 +119,7 @@ pub async fn update_account_handler(
 
 // ハンドラートレイト定義（グローバルスコープに移動）
 #[async_trait::async_trait]
-pub trait AccountHandler {
+pub trait AccountHandler: Interface {
     async fn create_account(
         &self,
         app_data: web::Data<AppData>,
@@ -149,7 +149,8 @@ pub trait AccountHandler {
 }
 
 /// 口座情報ハンドラーの実装
-#[derive(Clone, Default)]
+#[derive(Clone, Component, Default)]
+#[shaku(interface = AccountHandler)]
 pub struct AccountHandlerImpl;
 
 impl AccountHandlerImpl {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> std::io::Result<()> {
         Some(Commands::Version { verbose }) => {
             version::show_version(*verbose);
             return Ok(());
-        }
+        },
         None => {
             dotenv().ok();
             logging::init_logger();

--- a/src/utils/app_setup.rs
+++ b/src/utils/app_setup.rs
@@ -1,31 +1,42 @@
-use crate::dao::accounts::AccountDaoImpl;
-use crate::handler::accounts::{self, AccountHandlerImpl};
+use crate::dao::accounts::{AccountDao, AccountDaoImpl};
+use crate::handler::accounts::{self, AccountHandler, AccountHandlerImpl};
 use crate::handler::swagger_ui;
 use actix_web::{App, HttpResponse, HttpServer, Responder, web};
 use log::{debug, info};
 use serde_json::json;
+use shaku::{HasComponent, module};
 use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
 use std::env;
+use std::sync::Arc;
 
 const DEFAULT_DATABASE_URL: &str = "sqlite:./ebisu.db";
 const DEFAULT_MAX_CONNECTIONS: &str = "5";
 const DEFAULT_SERVER_ADDRESS: &str = "127.0.0.1";
 const DEFAULT_SERVER_PORT: &str = "8180";
 
+// Shakuのモジュール定義
+module! {
+    pub AppModule {
+        components = [AccountDaoImpl, AccountHandlerImpl],
+        providers = []
+    }
+}
+
 // DAOインスタンスをセットするための構造体
 #[derive(Clone)]
 pub struct AppData {
     pub db_pool: SqlitePool,
-    pub account_dao: AccountDaoImpl,
-    pub account_handler: AccountHandlerImpl,
+    pub account_dao: Arc<dyn AccountDao>,
+    pub account_handler: Arc<dyn AccountHandler>,
 }
 
 /// DAOのインスタンスを作成してAppDataにセットする関数
 pub fn create_app_data(pool: &SqlitePool) -> AppData {
+    let module = AppModule::builder().build();
     AppData {
         db_pool: pool.clone(),
-        account_dao: AccountDaoImpl,
-        account_handler: AccountHandlerImpl,
+        account_dao: module.resolve(),
+        account_handler: module.resolve(),
     }
 }
 

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -2,11 +2,12 @@ include!(concat!(env!("CARGO_MANIFEST_DIR"), "/build_number.rs"));
 
 /// バージョン情報を出力する関数
 pub fn show_version(verbose: bool) {
-	// Cargo.tomlのバージョン情報を埋め込む
-	println!("{name} v{version}",
-		name=env!("CARGO_PKG_NAME"),
-		version=format!("{}.{}", env!("CARGO_PKG_VERSION"), BUILD_NUMBER),
-	);
+    // Cargo.tomlのバージョン情報を埋め込む
+    println!(
+        "{name} v{version}",
+        name = env!("CARGO_PKG_NAME"),
+        version = format!("{}.{}", env!("CARGO_PKG_VERSION"), BUILD_NUMBER),
+    );
     if verbose {
         show_version_with_verbose();
     }
@@ -14,10 +15,10 @@ pub fn show_version(verbose: bool) {
 
 /// 詳細なバージョン情報を出力する関数
 pub fn show_version_with_verbose() {
-	println!(
-		"\nDescription: {desc}\nRust Edition: {edition}\nAuthor(s):\n  {authors}",
-		desc = env!("CARGO_PKG_DESCRIPTION"),
-		edition = EDITION,
-		authors = env!("CARGO_PKG_AUTHORS"),
-	);
+    println!(
+        "\nDescription: {desc}\nRust Edition: {edition}\nAuthor(s):\n  {authors}",
+        desc = env!("CARGO_PKG_DESCRIPTION"),
+        edition = EDITION,
+        authors = env!("CARGO_PKG_AUTHORS"),
+    );
 }

--- a/tests/handler/accounts.rs
+++ b/tests/handler/accounts.rs
@@ -27,9 +27,7 @@ async fn call_api(
     send_body: Option<&Account>,
 ) -> ServiceResponse {
     let app_data = create_app_data(&pool);
-    let app = test::init_service(App::new()
-        .app_data(web::Data::new(app_data))
-        .configure(accounts_configure)).await;
+    let app = test::init_service(App::new().app_data(web::Data::new(app_data)).configure(accounts_configure)).await;
     let req = {
         match method {
             HttpMethod::GET => test::TestRequest::get().uri(api_path).to_request(),


### PR DESCRIPTION
For task #46 .

feat: shakuによるDIコンテナ導入・Dao/HandlerのDI化

- shakuクレートをCargo.tomlに追加し、DIコンテナ機能を導入
- AccountDao/AccountHandlerトレイトにshaku::Interfaceを継承、Component deriveを付与
- AccountDaoImpl/AccountHandlerImplをshakuのcomponentsとしてAppModuleに登録
- AppModule（module!マクロ）を新規定義し、依存解決を型安全に
- create_app_data()でAppModuleからresolve()し、AppDataにArc<dyn Trait>で格納
- AppDataの型定義をArc<dyn AccountDao>/Arc<dyn AccountHandler>に統一
- 既存のDao/Handler生成・DI部分をshaku経由にリファクタ
- .copilot-commit-message-instructions.mdを新規追加（コミットメッセージルール明記）