### PR TITLE
feat: テスト用のモジュールとモックを追加し、テストのセットアップを改善

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
+backtrace = "0.3.76"
 sqlx-cli = { version = "0.8" }
 
 [build-dependencies]

--- a/src/handler/accounts.rs
+++ b/src/handler/accounts.rs
@@ -369,46 +369,106 @@ impl AccountHandler for AccountHandlerImpl {
 mod tests {
     use super::*;
     use crate::utils::unit_test::fixtures::accounts as fixtures_accounts;
+    use crate::utils::unit_test::fixtures::accounts::{
+        ParametrizedMockAccountDaoImpl, ParametrizedMockAccountDaoImplParameters,
+    };
+    use crate::utils::unit_test::fixtures::app_test_setup::TestAppModule;
     use crate::utils::unit_test::fixtures::db as fixtures_db;
     use actix_web::body::to_bytes;
     use actix_web::http::StatusCode;
-    use actix_web::web;
-    use once_cell::sync::Lazy;
 
-    static APP_MODULE: Lazy<AppModule> = Lazy::new(|| AppModule::builder().build());
-    static HANDLER: Lazy<Arc<dyn AccountHandler>> = Lazy::new(|| {
-        let handler: Arc<dyn AccountHandler> = APP_MODULE.resolve();
-        handler
-    });
-
-    async fn setup() -> (web::Data<SqlitePool>, Arc<dyn AccountHandler>) {
-        let (pool, _handler) = setup_empty().await;
-        fixtures_accounts::insert_test_account(&pool).await;
-        (pool, HANDLER.clone())
-    }
-
-    async fn setup_empty() -> (web::Data<SqlitePool>, Arc<dyn AccountHandler>) {
-        let pool = web::Data::new(fixtures_db::create_test_db().await);
-        (pool, HANDLER.clone())
-    }
-
-    async fn setup_undefined() -> (web::Data<SqlitePool>, Arc<dyn AccountHandler>) {
+    async fn setup(
+        parameters: ParametrizedMockAccountDaoImplParameters,
+    ) -> (web::Data<SqlitePool>, Arc<dyn AccountHandler>) {
         let pool = web::Data::new(fixtures_db::create_undefined_db().await);
-        (pool, HANDLER.clone())
+        let add_module =
+            TestAppModule::builder().with_component_parameters::<ParametrizedMockAccountDaoImpl>(parameters).build();
+        (pool, add_module.resolve())
+    }
+
+    pub fn get_normal_params() -> ParametrizedMockAccountDaoImplParameters {
+        ParametrizedMockAccountDaoImplParameters {
+            error_on_create: false,
+            error_on_get: false,
+            error_on_update: false,
+            error_on_delete: false,
+            get_return_empty: false,
+            get_in_create_return_empty: true,
+            create_return_empty: false,
+            update_return_empty: false,
+            delete_return_empty: false,
+        }
+    }
+
+    pub fn get_exists_account_params() -> ParametrizedMockAccountDaoImplParameters {
+        ParametrizedMockAccountDaoImplParameters {
+            error_on_create: false,
+            error_on_get: false,
+            error_on_update: false,
+            error_on_delete: false,
+            get_return_empty: false,
+            get_in_create_return_empty: false,
+            create_return_empty: false,
+            update_return_empty: false,
+            delete_return_empty: false,
+        }
+    }
+
+    pub fn get_empty_params() -> ParametrizedMockAccountDaoImplParameters {
+        ParametrizedMockAccountDaoImplParameters {
+            error_on_create: false,
+            error_on_get: false,
+            error_on_update: false,
+            error_on_delete: false,
+            get_return_empty: true,
+            get_in_create_return_empty: true,
+            create_return_empty: true,
+            update_return_empty: true,
+            delete_return_empty: true,
+        }
+    }
+
+    pub fn get_error_params() -> ParametrizedMockAccountDaoImplParameters {
+        ParametrizedMockAccountDaoImplParameters {
+            error_on_create: true,
+            error_on_get: true,
+            error_on_update: true,
+            error_on_delete: true,
+            get_return_empty: false,
+            get_in_create_return_empty: true,
+            create_return_empty: false,
+            update_return_empty: false,
+            delete_return_empty: false,
+        }
+    }
+
+    pub fn get_error_on_creation_params() -> ParametrizedMockAccountDaoImplParameters {
+        ParametrizedMockAccountDaoImplParameters {
+            error_on_create: true,
+            error_on_get: false,
+            error_on_update: true,
+            error_on_delete: true,
+            get_return_empty: false,
+            get_in_create_return_empty: true,
+            create_return_empty: false,
+            update_return_empty: false,
+            delete_return_empty: false,
+        }
     }
 
     mod create_account {
+
         use super::*;
 
         #[tokio::test]
         async fn create_success() {
             // preparation
-            let (pool, _handler) = setup_empty().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let new_account = fixtures_accounts::get_first_account();
             let new_account_json = web::Json(new_account.clone());
             // execution
             let resp = _handler.create_account(pool, new_account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::CREATED);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -418,12 +478,12 @@ mod tests {
         #[tokio::test]
         async fn create_conflict() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_exists_account_params()).await;
             let existing_account = fixtures_accounts::get_first_account();
             let existing_account_json = web::Json(existing_account.clone());
             // execution
             let resp = _handler.create_account(pool, existing_account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::CONFLICT);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -433,12 +493,12 @@ mod tests {
         #[tokio::test]
         async fn create_servererror_on_check_exists() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             let new_account = fixtures_accounts::get_first_account();
             let new_account_json = web::Json(new_account.clone());
             // execution
             let resp = _handler.create_account(pool, new_account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -446,20 +506,20 @@ mod tests {
         }
 
         // TODO: モックを使えるようになってから
-        // #[tokio::test]
-        // async fn create_servererror_on_creation() {
-        //     // preparation
-        //     let (pool, app_module, _handler) = setup().await;
-        //     let new_account = fixtures_accounts::get_first_account();
-        //     let new_account_json = web::Json(new_account.clone());
-        //     // execution
-        //     let resp = _handler.create_account(pool, app_module, new_account_json).await.unwrap();
-        //     // assersion
-        //     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        //     let body_bytes = to_bytes(resp.into_body()).await.unwrap();
-        //     let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-        //     assert_eq!(body, json!({"error": "Failed to create account."}));
-        // }
+        #[tokio::test]
+        async fn create_servererror_on_creation() {
+            // preparation
+            let (pool, _handler) = setup(get_error_on_creation_params()).await;
+            let new_account = fixtures_accounts::get_first_account();
+            let new_account_json = web::Json(new_account.clone());
+            // execution
+            let resp = _handler.create_account(pool, new_account_json).await.unwrap();
+            // assertion
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body, json!({"error": "Failed to create account."}));
+        }
     }
 
     mod get_accounts_list_all {
@@ -468,10 +528,10 @@ mod tests {
         #[tokio::test]
         async fn get_all_is_empty() {
             // preparation
-            let (pool, _handler) = setup_empty().await;
+            let (pool, _handler) = setup(get_empty_params()).await;
             // execution
             let resp = _handler.get_accounts_list_all(pool).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::OK);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
@@ -481,11 +541,11 @@ mod tests {
         #[tokio::test]
         async fn get_all_found_3accounts() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let account_list = fixtures_accounts::get_sorted_account_list();
             // execution
             let resp = _handler.get_accounts_list_all(pool).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::OK);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
@@ -498,10 +558,10 @@ mod tests {
         #[tokio::test]
         async fn get_all_servererror() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             // execution
             let resp = _handler.get_accounts_list_all(pool).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -515,11 +575,11 @@ mod tests {
         #[tokio::test]
         async fn get_type_not_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_empty_params()).await;
             let path = web::Path::from("Other".to_string());
             // execution
             let resp = _handler.get_accounts_list_by_type(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::NOT_FOUND);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -529,12 +589,12 @@ mod tests {
         #[tokio::test]
         async fn get_type_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let account = fixtures_accounts::get_first_account();
             let path = web::Path::from(account.account_type.name.clone());
             // execution
             let resp = _handler.get_accounts_list_by_type(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::OK);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let accounts: Vec<Account> = serde_json::from_slice(&body_bytes).unwrap();
@@ -545,12 +605,12 @@ mod tests {
         #[tokio::test]
         async fn get_type_servererror() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             let account = fixtures_accounts::get_first_account();
             let path = web::Path::from(account.account_type.name.clone());
             // execution
             let resp = _handler.get_accounts_list_by_type(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -564,11 +624,11 @@ mod tests {
         #[tokio::test]
         async fn get_by_id_not_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_empty_params()).await;
             let path = web::Path::from("nonexistent_id".to_string());
             // execution
             let resp = _handler.get_account_by_id(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::NOT_FOUND);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -578,12 +638,12 @@ mod tests {
         #[tokio::test]
         async fn get_by_id_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let account = fixtures_accounts::get_first_account();
             let path = web::Path::from(account.id.clone());
             // execution
             let resp = _handler.get_account_by_id(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::OK);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let fetched_account: Account = serde_json::from_slice(&body_bytes).unwrap();
@@ -593,11 +653,11 @@ mod tests {
         #[tokio::test]
         async fn get_by_id_servererror() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             let path = web::Path::from("any_id".to_string());
             // execution
             let resp = _handler.get_account_by_id(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -611,11 +671,11 @@ mod tests {
         #[tokio::test]
         async fn delete_not_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_empty_params()).await;
             let path = web::Path::from("nonexistent_id".to_string());
             // execution
             let resp = _handler.delete_account(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::NOT_FOUND);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -625,23 +685,23 @@ mod tests {
         #[tokio::test]
         async fn delete_success() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let account = fixtures_accounts::get_first_account();
             let path = web::Path::from(account.id.clone());
             // execution
             let resp = _handler.delete_account(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::NO_CONTENT);
         }
 
         #[tokio::test]
         async fn delete_servererror() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             let path = web::Path::from("any_id".to_string());
             // execution
             let resp = _handler.delete_account(pool, path).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -655,12 +715,12 @@ mod tests {
         #[tokio::test]
         async fn update_not_found() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_empty_params()).await;
             let account = fixtures_accounts::create_new_account();
             let account_json = web::Json(account);
             // execution
             let resp = _handler.update_account(pool, account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::NOT_FOUND);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -670,13 +730,13 @@ mod tests {
         #[tokio::test]
         async fn update_success() {
             // preparation
-            let (pool, _handler) = setup().await;
+            let (pool, _handler) = setup(get_normal_params()).await;
             let mut account = fixtures_accounts::get_first_account();
             account.memo = Some("更新されたメモ".to_string());
             let account_json = web::Json(account.clone());
             // execution
             let resp = _handler.update_account(pool, account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::OK);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
@@ -686,12 +746,12 @@ mod tests {
         #[tokio::test]
         async fn update_servererror() {
             // preparation
-            let (pool, _handler) = setup_undefined().await;
+            let (pool, _handler) = setup(get_error_params()).await;
             let account = fixtures_accounts::get_first_account();
             let account_json = web::Json(account);
             // execution
             let resp = _handler.update_account(pool, account_json).await.unwrap();
-            // assersion
+            // assertion
             assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
             let body_bytes = to_bytes(resp.into_body()).await.unwrap();
             let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();

--- a/src/utils/unit_test/fixtures/accounts.rs
+++ b/src/utils/unit_test/fixtures/accounts.rs
@@ -1,6 +1,9 @@
-#[cfg(test)]
+#![cfg(test)]
+use crate::dao::accounts::AccountDao;
 use crate::entity::accounts::{Account, AccountType};
+use backtrace::Backtrace;
 use serde::Deserialize;
+use shaku::Component;
 use sqlx::SqlitePool;
 use std::fs;
 
@@ -74,10 +77,12 @@ pub fn get_sorted_account_list() -> Vec<Account> {
     accounts
 }
 
+// テスト用のソート済みのリストの最初の口座を取得するヘルパー関数
 pub fn get_first_account() -> Account {
     get_sorted_account_list().first().unwrap().clone()
 }
 
+// 追加用の新しい口座データを作成するヘルパー関数
 pub fn create_new_account() -> Account {
     Account {
         id: "44444444-4444-4444-4444-444444444444".to_string(),
@@ -89,5 +94,107 @@ pub fn create_new_account() -> Account {
         memo: Some("追加の普通口座のメモ".to_string()),
         created_at: None,
         updated_at: None,
+    }
+}
+
+// モックで呼び出し元がcreate_account関数かどうかを判定するヘルパー関数
+fn is_called_from_create_account(bt: &Backtrace) -> bool {
+    let called_from_create_account = false;
+    for frame in bt.frames() {
+        for symbol in frame.symbols() {
+            if let Some(name) = symbol.name() {
+                if name.to_string().contains("create_account") {
+                    return true;
+                }
+            }
+        }
+    }
+    called_from_create_account
+}
+
+/// テスト用のAccountDaoモック(正常系)
+#[derive(Clone, Component)]
+#[shaku(interface = AccountDao)]
+pub struct ParametrizedMockAccountDaoImpl {
+    pub error_on_create: bool,
+    pub error_on_get: bool,
+    pub error_on_update: bool,
+    pub error_on_delete: bool,
+    pub get_return_empty: bool,
+    pub get_in_create_return_empty: bool,
+    pub create_return_empty: bool,
+    pub update_return_empty: bool,
+    pub delete_return_empty: bool,
+}
+
+#[async_trait::async_trait]
+impl AccountDao for ParametrizedMockAccountDaoImpl {
+    async fn get_accounts_list_all(&self, _pool: &SqlitePool) -> sqlx::Result<Vec<Account>> {
+        if self.error_on_get {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.get_return_empty {
+            return Ok(vec![]);
+        }
+        Ok(get_sorted_account_list())
+    }
+
+    async fn get_accounts_list_by_type(
+        &self,
+        _pool: &SqlitePool,
+        account_type_name: &str,
+    ) -> sqlx::Result<Vec<Account>> {
+        if self.error_on_get {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.get_return_empty {
+            return Ok(vec![]);
+        }
+        let accounts: Vec<Account> =
+            get_account_list().into_iter().filter(|acc| acc.account_type.name == account_type_name).collect();
+        Ok(accounts)
+    }
+
+    async fn get_account_by_id(&self, _pool: &SqlitePool, id: &str) -> sqlx::Result<Option<Account>> {
+        if self.error_on_get {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.get_return_empty
+            || (self.get_in_create_return_empty && is_called_from_create_account(&Backtrace::new()))
+        {
+            return Ok(None);
+        }
+        let account = get_account_list().into_iter().find(|acc| acc.id == id);
+        Ok(account)
+    }
+
+    async fn create_account(&self, _pool: &SqlitePool, _account: &Account) -> sqlx::Result<u64> {
+        if self.error_on_create {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.create_return_empty {
+            return Ok(0);
+        }
+        Ok(1)
+    }
+
+    async fn update_account(&self, _pool: &SqlitePool, _account: &Account) -> sqlx::Result<u64> {
+        if self.error_on_update {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.update_return_empty {
+            return Ok(0);
+        }
+        Ok(1)
+    }
+
+    async fn delete_account(&self, _pool: &SqlitePool, _id: &str) -> sqlx::Result<u64> {
+        if self.error_on_delete {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if self.delete_return_empty {
+            return Ok(0);
+        }
+        Ok(1)
     }
 }

--- a/src/utils/unit_test/fixtures/app_test_setup.rs
+++ b/src/utils/unit_test/fixtures/app_test_setup.rs
@@ -1,0 +1,12 @@
+#![cfg(test)]
+use crate::handler::accounts::AccountHandlerImpl;
+use crate::utils::unit_test::fixtures::accounts::ParametrizedMockAccountDaoImpl;
+use shaku::module;
+
+// テスト用のモジュールとモックを定義
+module! {
+    pub TestAppModule {
+        components = [ParametrizedMockAccountDaoImpl, AccountHandlerImpl],
+        providers = []
+    }
+}

--- a/src/utils/unit_test/fixtures/db.rs
+++ b/src/utils/unit_test/fixtures/db.rs
@@ -4,7 +4,6 @@ use std::fs;
 use uuid::Uuid;
 
 const MIGRATIONS_DIR: &str = "./migrations";
-const UNDEFINED_DB: &str = "./undefined.db";
 
 // テスト用のインメモリSQLiteデータベースをセットアップするヘルパー関数
 pub async fn create_test_db() -> SqlitePool {
@@ -32,8 +31,8 @@ pub async fn create_test_db() -> SqlitePool {
 
 // スキーマが設定されていないDBへのアクセスプールを作成する
 pub async fn create_undefined_db() -> SqlitePool {
-    fs::OpenOptions::new().write(true).create(true).open(UNDEFINED_DB).expect("Failed to create undefined.db file");
-    let db_url = format!("sqlite:{}", UNDEFINED_DB);
-    let pool = SqlitePoolOptions::new().connect(&db_url).await.unwrap();
+    let db_name = format!("file:memdb-{}", Uuid::new_v4().to_string());
+    let db_url = format!("{}?mode=memory&cache=shared", db_name);
+    let pool = SqlitePoolOptions::new().max_connections(1).connect(&db_url).await.unwrap();
     pool
 }

--- a/src/utils/unit_test/fixtures/mod.rs
+++ b/src/utils/unit_test/fixtures/mod.rs
@@ -1,3 +1,4 @@
-#[cfg(test)]
+#![cfg(test)]
 pub mod accounts;
+pub mod app_test_setup;
 pub mod db;


### PR DESCRIPTION
## 📝 関連するIssue

Closes #48

## 🌳 ブランチ

* **from:** `task/AddTestMock#48`
* **to:** `feature/TraitObjectImplemetation#11`

## ✨ このPRの変更点

- テスト用のAccountDaoモック（正常系・空・エラー・作成エラー）を `fixtures/accounts.rs` に集約・実装
- shakuによるテスト用DIモジュール（`TestAppModule`等）を `fixtures/app_test_setup.rs` に追加
- handlerのテストsetup関数をDI切替・インメモリDB化で整理
- `create_undefined_db()` をファイルDBからインメモリDBへ変更
- テスト資産の集約・可読性向上

## ✅ チェックリスト

Pull Requestをレビュー依頼する前に、以下の項目を確認してください。

-   [x] `cargo fmt` を実行しましたか？
-   [x] `cargo test` を実行し、すべてのテストがパスしましたか？
-   [x] 変更内容をカバーする十分なテストを追加または修正しましたか？
-   [x] `AGENTS.md`の規約に準拠していますか？

## 🧪 テスト方法 (任意)

1. `cargo test` を実行し、handlerの単体テストがすべてパスすることを確認
2. テストはインメモリDB・DIモジュール切替で正常系/異常系を網羅

## 💬 その他 (任意)

- テスト用モック・DI設計は今後他DAOやサービスにも展開可能です
- `AGENTS.md`や既存ドキュメントには影響ありません
